### PR TITLE
Toolchain fixes and native-hello example

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,7 @@
 .git
 
 # partial copy of .gitignore
+
+# Never copy host toolchain output: wrong OS/arch (e.g. macOS Mach-O in ROOT/amd64)
+# and it would appear before /src/bin on PATH, breaking mk in the image.
+ROOT

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,12 @@ RUN apt-get install -y --no-install-recommends gcc libc6-dev byacc
 WORKDIR /src
 COPY . .
 
+# build-mk.sh copies into ROOT/$GOARCH/{lib,bin}; host ROOT/ is dockerignored.
+# rc looks for #9/etc/rcmain.unix under GOROOT (ROOT); copy from ./etc.
+RUN mkdir -p ROOT/arm64/lib ROOT/arm64/bin ROOT/amd64/lib ROOT/amd64/bin \
+	ROOT/etc \
+	&& cp -a etc/. ROOT/etc/
+
 # Small shell script (not GNU autoconf) to detect arch and generate ./mkconfig
 RUN ./configure
 
@@ -42,7 +48,8 @@ RUN mk
 RUN mk install
 
 ENV GOOS="linux"
-ENV PATH="/src/ROOT/amd64/bin:/src/ROOT/arm64/bin:${PATH}"
+# Promoted mk/rc in /src/bin must win over ROOT/*/bin (see .dockerignore for ROOT).
+ENV PATH="/src/bin:/src/ROOT/amd64/bin:/src/ROOT/arm64/bin:${PATH}"
 
 ###############################################################################
 # Stage2: Just binaries (on amd64/arm64)

--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,16 @@ test:
 hellotest:
 	echo TODO
 
+# CPU count for docker --build-arg NPROC (macOS has no nproc; match env.sh)
+NPROC_FOR_DOCKER := $(shell if [ "`uname -s`" = Darwin ]; then sysctl -n hw.ncpu 2>/dev/null || echo 1; else nproc 2>/dev/null || echo 1; fi)
+
 # works for both amd64 and arm64
 build-docker:
-	docker build --tag "padator/goken:"`uname -m` -f Dockerfile --build-arg NPROC=`nproc` --target build .
+	docker build --tag "padator/goken:"`uname -m` -f Dockerfile --build-arg NPROC=$(NPROC_FOR_DOCKER) --target build .
 build-docker-test: 
-	docker build -f Dockerfile --build-arg NPROC=`nproc` --tag goken9cc-test --target test .
+	docker build -f Dockerfile --build-arg NPROC=$(NPROC_FOR_DOCKER) --tag goken9cc-test --target test .
 build-docker-principia: 
-	docker build -f Dockerfile --build-arg NPROC=`nproc` --tag goken9cc-principia --target principia .
+	docker build -f Dockerfile --build-arg NPROC=$(NPROC_FOR_DOCKER) --tag goken9cc-principia --target principia .
 
 # need 'docker login -u padator' first with credentials of
 # https://hub.docker.com/r/padator/ stored in ~/.docker/config.json

--- a/env.sh
+++ b/env.sh
@@ -6,8 +6,15 @@ export PATH=`pwd`/bin:`pwd`/ROOT/amd64/bin:`pwd`/ROOT/arm64/bin:$PATH
 export MKSHELL=`pwd`/bin/rc
 # disable leak detection when built with --asan; many tools have harmless leaks
 export ASAN_OPTIONS=detect_leaks=0
-# for mk to use multiple processors
-export NPROC=`nproc`
+# for mk to use multiple processors (macOS has no nproc)
+case `uname -s` in
+Darwin)
+	export NPROC=`sysctl -n hw.ncpu 2>/dev/null || echo 1`
+	;;
+*)
+	export NPROC=`nproc 2>/dev/null || echo 1`
+	;;
+esac
 
 # old: not needed anymore thx to get9root.c and the use of #9/etc/...
 # alt: can also be overriden with setting GOROOT

--- a/examples/native-hello/.gitignore
+++ b/examples/native-hello/.gitignore
@@ -1,0 +1,6 @@
+hello
+*.6
+*.7
+*.8
+*.5
+libhello.a

--- a/examples/native-hello/build-hello.sh
+++ b/examples/native-hello/build-hello.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Build hello.c with this repo's goken9cc (see CLAUDE.md: configure, build-mk, promote, make install).
+#
+# Targets macOS: Mach-O x86_64 (GOOS=darwin, GOARCH=amd64) via 6c/6a/6l. Only the amd64 linker
+# implements a usable Mach-O header in this tree; arm64 Mach-O is not wired in 7l.
+#
+# Uses the same tiny runtime as tests/c/mini (start_amd64.s, xwrite_amd64.s, xexit_amd64.s) so we
+# do not need u.h (the Plan 9 preprocessor in [67]c does not accept all of include/u.h on macOS).
+#
+# On Apple Silicon you get an x86_64 binary (run under Rosetta if enabled). Some macOS versions
+# report Rosetta errors for statically linked Plan 9-style Mach-O; an Intel Mac is the most
+# reliable place to run ./hello.
+set -eu
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+TOP=$(cd "$HERE/../.." && pwd)
+MINI=$TOP/tests/c/mini
+
+# Mach-O output: always amd64 object pipeline (see src/cmd/6l/obj.c: darwin -> -H6).
+GOOS=darwin
+GOARCH=amd64
+CC=6c
+AS=6a
+LD=6l
+O=6
+
+BIN=
+for d in "$TOP/ROOT/arm64/bin" "$TOP/ROOT/amd64/bin"; do
+	if test -x "$d/$CC" && test -x "$d/$LD"; then
+		BIN=$d
+		break
+	fi
+done
+if test -z "$BIN"; then
+	echo "missing $CC/$LD under ROOT/*/bin — build and install the toolchain first." >&2
+	exit 1
+fi
+
+export GOROOT=$TOP/ROOT
+export GOOS
+export GOARCH
+export PATH="/usr/bin:/bin:$TOP/bin:$BIN:$PATH"
+
+START=$MINI/start_amd64.s
+XW=$MINI/xwrite_amd64.s
+XE=$MINI/xexit_amd64.s
+for f in "$START" "$XW" "$XE"; do
+	if ! test -f "$f"; then
+		echo "missing $f" >&2
+		exit 1
+	fi
+done
+
+cd "$HERE"
+rm -f hello "hello.$O" libhello.a \
+	"start_$GOARCH.$O" "xwrite_$GOARCH.$O" "xexit_$GOARCH.$O"
+
+"$BIN/$AS" -D$GOARCH -c "$START"
+"$BIN/$AS" -D$GOARCH -c "$XW"
+"$BIN/$AS" -D$GOARCH -c "$XE"
+"$BIN/ar_" rc libhello.a "start_$GOARCH.$O" "xwrite_$GOARCH.$O" "xexit_$GOARCH.$O"
+"$BIN/$CC" -D$GOARCH -I"$TOP/include" hello.c
+"$BIN/$LD" -L. -o hello -E _start "hello.$O"
+
+echo "Built $HERE/hello (GOOS=$GOOS GOARCH=$GOARCH, Mach-O x86_64)."
+case $(uname -s)/$(uname -m) in
+Darwin/arm64 | Darwin/aarch64)
+	echo "Host is Apple Silicon: run ./hello with Rosetta if needed; if it aborts, try an Intel Mac." >&2
+	;;
+Darwin/*) ;;
+*)
+	echo "Built on $(uname -s): hello is a macOS binary; copy to a Mac to run." >&2
+	;;
+esac

--- a/examples/native-hello/hello.c
+++ b/examples/native-hello/hello.c
@@ -1,0 +1,11 @@
+#pragma lib "libhello.a"
+
+extern void xwrite(char*, int);
+extern void xexit(void);
+
+void
+main(void)
+{
+	xwrite("hello, world\n", 13);
+	xexit();
+}

--- a/utilities/calc/misc/bc.y
+++ b/utilities/calc/misc/bc.y
@@ -93,6 +93,7 @@
         void    routput(char*);
         void    tp(char*);
         void    yyerror(char*, ...);
+        int     yylex(void);
         int     yyparse(void);
 
         typedef void*   pointer;


### PR DESCRIPTION
## Summary
Draft PR bundling local `master` commits not yet on upstream:

- **calc**: forward-declare `yylex` in `bc.y` for modern Clang
- **env.sh / Makefile**: derive `NPROC` via `sysctl` on macOS; wire through Docker builds
- **Docker**: ignore host ROOT, seed ROOT layout for `mk test`
- **examples**: add `native-hello` sample (C, build script, gitignore)

No additional commits were made for this PR; branch `cursor/toolchain-and-native-hello` matches local `master` at push time.
