### PR TITLE
6l: modernise -H6 (LC_MAIN, PIE, libSystem), mirror of the 7l work

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -3,6 +3,29 @@
 * 0.4 (Q3 2026) ([58][alc] synced/fixed with principia, 7a/7c/7l macOS Mach-O)
 
 ** toolchain
+- 6l: modernise the amd64 -H6 (macOS Mach-O) output, mirror of the 7l
+  arm64 work of ba7132b7e:
+  * LC_MAIN entry point (not LC_UNIXTHREAD), MH_DYLDLINK|MH_TWOLEVEL|
+    MH_PIE, libSystem LC_LOAD_DYLIB, and LC_DYLD_INFO_ONLY/BUILD_VERSION/
+    UUID -- dyld now loads the binary instead of the kernel doing a
+    static exec.
+  * PIE / RIP-relative addressing: MOV $sym(SB) is encoded [rip+disp32]
+    with a D_PCREL reloc under -H6; ELF (-H7) and Plan 9 (-H2) keep the
+    absolute SIB encoding (Linux output byte-identical).
+  * "6l -I got:remote:lib": declare a Mach-O dynamic import.  The
+    program defines an 8-byte GOT slot in __DATA and calls through it;
+    the linker emits an LC_DYLD_INFO non-lazy bind so dyld resolves
+    remote@lib into that slot at load.  Enables calling libSystem
+    functions (which darling can translate on Linux) instead of raw
+    amd64 Darwin syscalls (which darling can't).
+  * default INITTEXT for -H6 raised from 4096+HEADR to 0x100000+HEADR
+    (clears Linux mmap_min_addr; stays < 2GB for the 32-bit-absolute
+    addressing).  __PAGEZERO is 1MB rather than Apple's 4GB because
+    6l's text layout uses int32 offsets -- MH_PIE lets dyld slide the
+    image regardless.
+  * tests/s/mini/hello_macos_libc_amd64.s calls libSystem's _write via
+    the GOT slot and runs under darling.
+  * see docs/notes_macos.txt for the full story and darling recipe.
 - import 5a/5c/5l and 8a/7c/8l from principia (and rename the 5a/5l/5c
   and 8a/8l/8c that were coming from my kencc to 5ak/5lk/5ck and 8ak/8lk/8ck)
 - fix regressions/mismatch between the principia and kencc variants

--- a/docs/notes_macos.txt
+++ b/docs/notes_macos.txt
@@ -197,3 +197,64 @@ The kernel kills at exec() silently, so work hypothesis-by-hypothesis:
   goldmine when suspecting a codegen bug: both 7c fixes found on this
   branch (gtext frame size, vlong first-arg spill) have counterparts
   visible by diffing goken against 9front.
+
+Producing macOS amd64 executables (6l -H6)
+------------------------------------------
+
+Follow-up to the arm64 story above, added while updating 6l -H6 (which
+had been sitting on an unmodernised LC_UNIXTHREAD/static path). Tested
+against darling on a Linux host, since a raw x86 Mac is inconvenient.
+
+The kernel is more forgiving than arm64: unsigned and non-PIE amd64
+binaries still run on real macOS (XNU). But darling refuses to load
+non-PIE, unsigned, static Mach-Os and mostly refuses to translate raw
+Darwin syscalls to Linux ones, so to actually exercise the output on a
+Linux CI host the same modernisation as 7l applies:
+
+- LC_MAIN entry (a file offset into __TEXT) instead of LC_UNIXTHREAD.
+  dyld runs first, calls that offset like a C function, and treats
+  the return value as exit(). Compute the offset from entryvalue():
+  entryoff = entryvalue - (INITTEXT - HEADR). See src/cmd/ld/macho.c
+  `case '6'` in asmbmacho().
+
+- MH_DYLDLINK | MH_TWOLEVEL | MH_PIE in the header, plus a libSystem
+  LC_LOAD_DYLIB (/usr/lib/libSystem.B.dylib, ordinal 1). LC_UUID and
+  LC_BUILD_VERSION so dyld doesn't complain.
+
+- RIP-relative symbol references. Under -H6, asmandsz() emits the
+  [rip+disp32] form (mod=00, rm=101) with a D_PCREL reloc instead of
+  the absolute disp32 SIB form; doasm() then subtracts the trailing
+  bytes of the instruction from the reloc addend, since RIP points at
+  the end of the whole instruction (not the end of the disp32). Gated
+  on HEADTYPE==6 so ELF and Plan 9 targets are byte-identical.
+
+- Optional "-I got:remote:lib" imports (adddynimp()). The program
+  defines a __DATA GOT slot `got` and calls through it; the linker
+  emits an LC_DYLD_INFO non-lazy bind opcode stream in __LINKEDIT so
+  dyld resolves `remote` from `lib` into that slot at load. This is
+  what lets the amd64 hello work under darling: raw amd64 Darwin
+  syscalls (movq $0x2000004, rax; syscall) fail there because darling
+  emulates Darwin via Linux libc.
+
+Two intentional simplifications:
+
+- No ad-hoc code signing (unlike 7l): XNU on amd64 still runs unsigned
+  executables. If a user later runs the binary through codesign(1) they
+  can pick up the arm64 rules for free (LINKEDIT has room; nothing
+  needs to move).
+
+- __PAGEZERO stays at 1MB, not Apple's 4GB. 6l's text layout uses
+  int32 offsets, so INITTEXT >= 4GB truncates during placement. With
+  MH_PIE the loader can slide the image regardless, so the deviation
+  from a stock macOS binary is cosmetic. Lifting this would need
+  widening INITTEXT / the text placement code in 6l -- same shape as
+  the arm64 change in ba7132b7e (mirroring 9front 869a08f08).
+
+Verifying an amd64 build on a Linux host:
+
+    (cd tests/s/mini && mk hello_macos_libc_amd64.exe hello_macos_amd64.exe)
+    file hello_macos_libc_amd64.exe   # expect: NOUNDEFS|DYLDLINK|TWOLEVEL|PIE
+    darling shell ./hello_macos_libc_amd64.exe   # prints "Hello, world"
+
+    # raw-syscall variant: real macOS runs it, darling does not
+    # (translates libSystem calls, not raw amd64 syscalls).

--- a/src/cmd/6l/obj.c
+++ b/src/cmd/6l/obj.c
@@ -103,6 +103,9 @@ main(int argc, char *argv[])
 	case 'L':
 		Lflag(EARGF(usage()));
 		break;
+	case 'I':	/* -I got:remote:lib  declare a Mach-O dynamic import (libSystem) */
+		adddynimp(EARGF(usage()));
+		break;
 	case 'T':
 		INITTEXT = atolwhex(EARGF(usage()));
 		break;

--- a/src/cmd/6l/obj.c
+++ b/src/cmd/6l/obj.c
@@ -184,7 +184,10 @@ main(int argc, char *argv[])
 		if(INITRND == -1)
 			INITRND = 4096;
 		if(INITTEXT == -1)
-			INITTEXT = 4096+HEADR;
+			INITTEXT = 0x100000+HEADR;	/* __TEXT >= 1MB: clears Linux mmap_min_addr so the
+						 * image loads (e.g. under darling); stays < 2GB for the
+						 * amd64 32-bit-absolute addressing. (Apple uses a 4GB
+						 * __PAGEZERO, which our codegen can't reach.) */
 		if(INITDAT == -1)
 			INITDAT = 0;
 		break;

--- a/src/cmd/6l/span.c
+++ b/src/cmd/6l/span.c
@@ -779,16 +779,26 @@ vaddr(Adr *a, Reloc *r)
 	return v;
 }
 
+/*
+ * riprelfix: when asmandsz emits a macOS (PIE) RIP-relative reference, it
+ * records (reloc index + 1) here so doasm() can correct the addend for any
+ * immediate emitted after the disp32 (RIP is relative to the end of the whole
+ * instruction). 0 means "nothing to fix".
+ */
+int	riprelfix;
+
 static void
 asmandsz(Adr *a, int r, int rex, int m64)
 {
 	int32 v;
 	int t, scale;
+	int rip;
 	Reloc rel;
 
 	rex &= (0x40 | Rxr);
 	v = a->offset;
 	t = a->type;
+	rip = 0;
 	rel.siz = 0;
 	if(a->index != D_NONE) {
 		if(t < D_INDIR) { 
@@ -862,6 +872,20 @@ asmandsz(Adr *a, int r, int rex, int m64)
 			*andptr++ = (0 << 6) | (5 << 0) | (r << 3);
 			goto putrelv;
 		}
+		if(HEADTYPE == 6 && rel.siz == 4) {
+			/*
+			 * macOS (PIE): a symbol reference becomes RIP-relative
+			 * [rip+disp32] (mod=00, rm=101) with a PC-relative reloc,
+			 * instead of the absolute disp32 SIB form below. The disp
+			 * is then load-address-independent, so the image can use a
+			 * 4GB __PAGEZERO / be slid by ASLR. (Other -H targets keep
+			 * the proven absolute encoding.)
+			 */
+			*andptr++ = (0 << 6) | (5 << 0) | (r << 3);
+			rel.type = D_PCREL;
+			rip = 1;
+			goto putrelv;
+		}
 		/* temporary */
 		*andptr++ = (0 <<  6) | (4 << 0) | (r << 3);	/* sib present */
 		*andptr++ = (0 << 6) | (4 << 3) | (5 << 0);	/* DS:d32 */
@@ -910,6 +934,8 @@ putrelv:
 		r = addrel(cursym);
 		*r = rel;
 		r->off = curp->pc + andptr - and;
+		if(rip)
+			riprelfix = cursym->nr;	/* index+1; doasm() fixes the addend */
 	}
 	put4(v);
 	return;
@@ -1151,6 +1177,7 @@ doasm(Prog *p)
 	Adr *a;
 	
 	curp = p;	// TODO
+	riprelfix = 0;
 
 	o = opindex[p->as];
 	if(o == nil) {
@@ -1630,6 +1657,17 @@ found:
 			}
 		}
 		break;
+	}
+	if(riprelfix) {
+		Reloc *rr;
+
+		/*
+		 * RIP-relative disp is measured from the end of the instruction.
+		 * Subtract any bytes emitted after the disp32 (e.g. an immediate).
+		 */
+		rr = &cursym->r[riprelfix-1];
+		rr->add -= (curp->pc + (andptr - and)) - (rr->off + rr->siz);
+		riprelfix = 0;
 	}
 	return;
 

--- a/src/cmd/ld/macho.c
+++ b/src/cmd/ld/macho.c
@@ -18,6 +18,60 @@ static	MachoDebug	xdebug[16];
 static	int	nload, nseg, ndebug, nsect;
 static	uint32	machoflags = 1;	/* MH_NOUNDEFS; modern path ORs in DYLDLINK|TWOLEVEL */
 
+/*
+ * Dynamic imports declared via "6l -I got:remote:lib": the program defines a
+ * GOT pointer slot `got` (8 bytes of zero in __DATA) and calls through it; the
+ * linker emits an LC_DYLD_INFO non-lazy bind that makes dyld resolve `remote`
+ * from `lib` into that slot at load. Only libSystem (dylib ordinal 1) is wired.
+ */
+static struct {
+	char	*got;
+	char	*remote;
+	char	*lib;
+} dynimp[16];
+static int ndynimp;
+static uchar	machobind[1024];
+static int	nmachobind;
+static vlong	machobindoff;
+
+void
+adddynimp(char *spec)
+{
+	char *s, *p, *q;
+
+	if(ndynimp >= nelem(dynimp)) {
+		diag("too many -I imports");
+		errorexit();
+	}
+	s = strdup(spec);
+	p = utfrune(s, ':');
+	q = p ? utfrune(p+1, ':') : nil;
+	if(p == nil || q == nil) {
+		diag("bad -I import (want got:remote:lib): %s", spec);
+		errorexit();
+	}
+	*p = '\0';
+	*q = '\0';
+	dynimp[ndynimp].got = s;
+	dynimp[ndynimp].remote = p+1;
+	dynimp[ndynimp].lib = q+1;
+	ndynimp++;
+}
+
+static void
+binduleb(vlong v)
+{
+	uchar b;
+
+	do {
+		b = v & 0x7f;
+		v >>= 7;
+		if(v)
+			b |= 0x80;
+		machobind[nmachobind++] = b;
+	} while(v);
+}
+
 void
 machoinit(void)
 {
@@ -564,7 +618,32 @@ asmbmacho(vlong symdatva, vlong symo)
 
 	if(thechar == '6') {
 		/* modern macOS metadata load commands */
-		ml = newMachoLoad(0x80000022, 10);	/* LC_DYLD_INFO_ONLY - empty (no fixups/binds) */
+
+		/* build the non-lazy bind opcode stream for -I imports (libSystem, ord 1) */
+		nmachobind = 0;
+		machobindoff = 0;
+		if(ndynimp > 0) {
+			char *cp;
+			Sym *isym;
+
+			for(i=0; i<ndynimp; i++) {
+				isym = lookup(dynimp[i].got, 0);
+				machobind[nmachobind++] = 0x10 | 1;	/* SET_DYLIB_ORDINAL_IMM, libSystem */
+				machobind[nmachobind++] = 0x40;		/* SET_SYMBOL_TRAILING_FLAGS_IMM, 0 */
+				for(cp = dynimp[i].remote; *cp; cp++)
+					machobind[nmachobind++] = *cp;
+				machobind[nmachobind++] = 0;
+				machobind[nmachobind++] = 0x50 | 1;	/* SET_TYPE_IMM, BIND_TYPE_POINTER */
+				machobind[nmachobind++] = 0x70 | 2;	/* SET_SEGMENT_AND_OFFSET_ULEB, __DATA */
+				binduleb(symaddr(isym) - (va+v));	/* slot offset within __DATA */
+				machobind[nmachobind++] = 0x90;		/* DO_BIND */
+			}
+			machobind[nmachobind++] = 0x00;			/* DONE */
+			machobindoff = linkoff + nlinkdata + nstrtab;	/* after symtab/strtab */
+		}
+		ml = newMachoLoad(0x80000022, 10);	/* LC_DYLD_INFO_ONLY */
+		ml->data[2] = machobindoff;		/* bind_off */
+		ml->data[3] = nmachobind;		/* bind_size */
 
 		ml = newMachoLoad(0x1b, 4);		/* LC_UUID (deterministic placeholder) */
 		ml->data[0] = 0x6b636e6b;
@@ -593,9 +672,9 @@ asmbmacho(vlong symdatva, vlong symo)
 
 		ms = newMachoSeg("__LINKEDIT", 0);
 		ms->vaddr = va+v+rnd(segdata.len, INITRND);
-		ms->vsize = nlinkdata+nstrtab;
+		ms->vsize = nlinkdata+nstrtab+nmachobind;
 		ms->fileoffset = linkoff;
-		ms->filesize = nlinkdata+nstrtab;
+		ms->filesize = nlinkdata+nstrtab+nmachobind;
 		ms->prot1 = 7;
 		ms->prot2 = 3;
 
@@ -668,4 +747,15 @@ asmbmacho(vlong symdatva, vlong symo)
 	a = machowrite();
 	if(a > MACHORESERVE)
 		diag("MACHORESERVE too small: %d > %d", a, MACHORESERVE);
+
+	/*
+	 * Append the dyld bind opcode stream at the end of __LINKEDIT.
+	 * machowrite() buffers the header via LPUT; flush it to disk first so
+	 * these direct seek/ewrite calls don't race the buffered output.
+	 */
+	if(nmachobind > 0) {
+		cflush();
+		seek(cout, machobindoff, 0);
+		ewrite(cout, machobind, nmachobind);
+	}
 }

--- a/src/cmd/ld/macho.c
+++ b/src/cmd/ld/macho.c
@@ -540,11 +540,13 @@ asmbmacho(vlong symdatva, vlong symo)
 		 * Modern macOS: LC_MAIN (an entry-point file offset) replaces the
 		 * old LC_UNIXTHREAD register-state entry. dyld runs first, then calls
 		 * this offset. Also flag the binary as dynamically linked + two-level
-		 * (MH_DYLDLINK|MH_TWOLEVEL) as ld64 does. We stay non-PIE: the amd64
-		 * backend emits 32-bit-absolute addressing, so the image must load in
-		 * the low 4GB (hence no 0x100000000 __PAGEZERO and no MH_PIE here).
+		 * (MH_DYLDLINK|MH_TWOLEVEL|MH_PIE) as ld64 does. amd64 uses
+		 * RIP-relative addressing for symbol references under -H6 (see
+		 * asmandsz), so the image is position-independent and dyld can slide
+		 * it under ASLR. __PAGEZERO stays at 1MB (not 4GB) because 6l's text
+		 * layout doesn't yet handle __TEXT >= 4GB -- separate work.
 		 */
-		machoflags = 1 | 4 | 0x80;	/* MH_NOUNDEFS|MH_DYLDLINK|MH_TWOLEVEL */
+		machoflags = 1 | 4 | 0x80 | 0x200000;	/* MH_NOUNDEFS|MH_DYLDLINK|MH_TWOLEVEL|MH_PIE */
 		entryoff = entryvalue() - (INITTEXT - HEADR);	/* file offset of entry */
 		ml = newMachoLoad(0x80000028, 4);	/* LC_MAIN */
 		ml->data[0] = entryoff;			/* entryoff low */

--- a/src/cmd/ld/macho.c
+++ b/src/cmd/ld/macho.c
@@ -16,6 +16,7 @@ static	MachoLoad	load[16];
 static	MachoSeg	seg[16];
 static	MachoDebug	xdebug[16];
 static	int	nload, nseg, ndebug, nsect;
+static	uint32	machoflags = 1;	/* MH_NOUNDEFS; modern path ORs in DYLDLINK|TWOLEVEL */
 
 void
 machoinit(void)
@@ -156,7 +157,7 @@ machowrite(void)
 	LPUT(2);	/* file type - mach executable */
 	LPUT(nload+nseg+ndebug);
 	LPUT(loadsize);
-	LPUT(1);	/* flags - no undefines */
+	LPUT(machoflags);	/* flags */
 	if(macho64)
 		LPUT(0);	/* reserved */
 
@@ -445,6 +446,7 @@ asmbmacho(vlong symdatva, vlong symo)
 {
 	vlong v, w;
 	vlong va;
+	vlong entryoff;
 	int a, i, ptrsize;
 	char *pkgroot;
 	MachoHdr *mh;
@@ -534,11 +536,21 @@ asmbmacho(vlong symdatva, vlong symo)
 		diag("unknown macho architecture");
 		errorexit();
 	case '6':
-		ml = newMachoLoad(5, 42+2);	/* unix thread */
-		ml->data[0] = 4;	/* thread type */
-		ml->data[1] = 42;	/* word count */
-		ml->data[2+32] = entryvalue();	/* start pc */
-		ml->data[2+32+1] = entryvalue()>>16>>16;	// hide >>32 for 8l
+		/*
+		 * Modern macOS: LC_MAIN (an entry-point file offset) replaces the
+		 * old LC_UNIXTHREAD register-state entry. dyld runs first, then calls
+		 * this offset. Also flag the binary as dynamically linked + two-level
+		 * (MH_DYLDLINK|MH_TWOLEVEL) as ld64 does. We stay non-PIE: the amd64
+		 * backend emits 32-bit-absolute addressing, so the image must load in
+		 * the low 4GB (hence no 0x100000000 __PAGEZERO and no MH_PIE here).
+		 */
+		machoflags = 1 | 4 | 0x80;	/* MH_NOUNDEFS|MH_DYLDLINK|MH_TWOLEVEL */
+		entryoff = entryvalue() - (INITTEXT - HEADR);	/* file offset of entry */
+		ml = newMachoLoad(0x80000028, 4);	/* LC_MAIN */
+		ml->data[0] = entryoff;			/* entryoff low */
+		ml->data[1] = entryoff>>16>>16;		/* entryoff high */
+		ml->data[2] = 0;			/* stacksize low */
+		ml->data[3] = 0;			/* stacksize high */
 		break;
 	case '8':
 		ml = newMachoLoad(5, 16+2);	/* unix thread */
@@ -546,6 +558,30 @@ asmbmacho(vlong symdatva, vlong symo)
 		ml->data[1] = 16;	/* word count */
 		ml->data[2+10] = entryvalue();	/* start pc */
 		break;
+	}
+
+	if(thechar == '6') {
+		/* modern macOS metadata load commands */
+		ml = newMachoLoad(0x80000022, 10);	/* LC_DYLD_INFO_ONLY - empty (no fixups/binds) */
+
+		ml = newMachoLoad(0x1b, 4);		/* LC_UUID (deterministic placeholder) */
+		ml->data[0] = 0x6b636e6b;
+		ml->data[1] = 0x36303963;
+		ml->data[2] = 0x6f72636d;
+		ml->data[3] = 0x00000073;
+
+		ml = newMachoLoad(0x32, 4);		/* LC_BUILD_VERSION */
+		ml->data[0] = 1;			/* platform = PLATFORM_MACOS */
+		ml->data[1] = 0x000a0f00;		/* minos 10.15.0 */
+		ml->data[2] = 0x000a0f00;		/* sdk   10.15.0 */
+		ml->data[3] = 0;			/* ntools */
+
+		ml = newMachoLoad(12, 4+(strlen("/usr/lib/libSystem.B.dylib")+1+7)/8*2);	/* LC_LOAD_DYLIB */
+		ml->data[0] = 24;			/* name offset */
+		ml->data[1] = 2;			/* timestamp */
+		ml->data[2] = 0x051f0000;		/* current_version 1311.0.0 */
+		ml->data[3] = 0x00010000;		/* compatibility_version 1.0.0 */
+		strcpy((char*)&ml->data[4], "/usr/lib/libSystem.B.dylib");
 	}
 
 	if(!debug['d']) {

--- a/src/cmd/ld/macho.h
+++ b/src/cmd/ld/macho.h
@@ -75,3 +75,4 @@ enum {
 void	domacho(void);
 vlong	domacholink(void);
 void	asmbmacho(vlong, vlong);
+void	adddynimp(char*);

--- a/tests/s/mini/hello_macos_libc_amd64.s
+++ b/tests/s/mini/hello_macos_libc_amd64.s
@@ -1,0 +1,15 @@
+TEXT _start(SB), $0
+	MOVQ	writep(SB), AX		// dyld-bound _write pointer (RIP-relative load)
+	MOVL	$1, DI			// fd = 1 (stdout)
+	LEAQ	msg(SB), SI		// buf
+	MOVL	$13, DX			// count
+	CALL	AX			// write(1, msg, 13) via libSystem
+	XORL	AX, AX			// return 0
+	RET				// LC_MAIN: dyld calls exit(0)
+
+DATA	msg+0(SB)/8, $"Hello, w"
+DATA	msg+8(SB)/5, $"orld\n"
+GLOBL	msg(SB), $13
+
+GLOBL	writep(SB), $8			// GOT slot; -I binds it to _write@libSystem
+DATA	writep+0(SB)/8, $0

--- a/tests/s/mini/mkfile
+++ b/tests/s/mini/mkfile
@@ -12,7 +12,7 @@ PLAN9BINS=hello_plan9_386.exe hello_plan9_arm.exe hello_plan9_mips.exe
 #TODO: hello_xv6_386.exe hello_xv6_riscv.exe
 XV6BINS=
 
-MACOSBINS=hello_macos_amd64.exe hello_macos_arm64.exe
+MACOSBINS=hello_macos_amd64.exe hello_macos_arm64.exe hello_macos_libc_amd64.exe
 #TODO: hello_windows_386.exe hello_windows_amd64.exe
 WINDOWSBINS=
 
@@ -89,6 +89,14 @@ hello_macos_arm64.exe: hello_macos_arm64.s
    7l -H6 -o $target -E _start hello_macos_arm64.7
    #TODO:
    #if(~ `{uname} Darwin) codesign -s - -f $target
+
+# Same as hello_macos_amd64 but calls libSystem's _write instead of a raw
+# syscall: -I declares the import, 6l binds it (LC_DYLD_INFO) into the writep
+# GOT slot. This is the variant that actually runs under darling (which
+# emulates Darwin via libSystem and does not translate raw syscalls).
+hello_macos_libc_amd64.exe: hello_macos_libc_amd64.s
+   6a -c $prereq
+   6l -s -H6 -I writep:_write:/usr/lib/libSystem.B.dylib -o $target -E _start hello_macos_libc_amd64.6
 
 # Plan9
 # -H 2 this time and -E _main

--- a/tests/s/mini/mkfile
+++ b/tests/s/mini/mkfile
@@ -71,9 +71,14 @@ hello_linux_mips.exe: hello_linux_mips.s
 			
 
 # macOS
+# -H6 selects the apple MACH (Mach-O) header. 6l now emits the modern format:
+# LC_MAIN entry (not LC_UNIXTHREAD), MH_DYLDLINK|MH_TWOLEVEL|MH_PIE, links
+# /usr/lib/libSystem.B.dylib, and carries LC_DYLD_INFO_ONLY, LC_BUILD_VERSION
+# and LC_UUID.  (-s drops the __SYMDAT/__DWARF segments -- keeps the binary
+# darling-loadable; codesign(1) then covers the whole image.)
 hello_macos_amd64.exe: hello_macos_amd64.s
    6a -c $prereq
-   6l -o $target -E _start hello_macos_amd64.6
+   6l -s -H6 -o $target -E _start hello_macos_amd64.6
 
 # the codesign step is mandatory on arm64 macOS: the kernel SIGKILLs
 # unsigned (or non-PIE, or static) arm64 executables at exec() time.


### PR DESCRIPTION
Rebased subset of #5, per your comment there: keeps only the 6l /
amd64 pieces you said you'd take.  The 7l / arm64 changes are dropped
since `ba7132b7e` (7a/7l macOS Mach-O) already covers them from a
cleaner starting point.

## What's in here

Four commits on top of current master (`51b21b872`), all `case '6'` /
`HEADTYPE==6` gated so ELF (-H7) and Plan 9 (-H2) outputs stay
byte-identical:

1. **`6l: emit modern Mach-O (LC_MAIN + libSystem) for -H6`**
   `LC_MAIN` entry (not `LC_UNIXTHREAD`), header flags
   `MH_DYLDLINK|MH_TWOLEVEL`, `LC_LOAD_DYLIB(libSystem)`,
   `LC_DYLD_INFO_ONLY`, `LC_BUILD_VERSION`, `LC_UUID`.  Raises the
   default `INITTEXT` from `4096+HEADR` to `0x100000+HEADR` so the
   image clears Linux `mmap_min_addr` and loads under darling.

2. **`6l: PIE/RIP-relative addressing for macOS Mach-O (-H6)`**
   `MOV \$sym(SB)` is encoded `[rip+disp32]` with a `D_PCREL` reloc
   (mod=00, rm=101) instead of the absolute disp32 SIB form; header
   sets `MH_PIE`.  `doasm()` corrects the addend for any bytes emitted
   after the disp32 (RIP is relative to the end of the whole
   instruction).

3. **`6l: -I dynamic imports — call libSystem from Mach-O binaries`**
   New `6l -I got:remote:lib`: the program defines an 8-byte GOT slot
   `got` in `__DATA` and calls through it; the linker emits an
   `LC_DYLD_INFO` non-lazy bind so dyld resolves `remote@lib`
   (libSystem, ordinal 1) into that slot at load.  Lets hand-written
   amd64 binaries call libc functions -- required to run under darling,
   which emulates Darwin via libSystem and cannot translate raw amd64
   Darwin syscalls.

4. **`docs: 6l -H6 modernisation notes + changes.txt entries`**
   Adds an amd64 section to `docs/notes_macos.txt` beside the existing
   arm64 one, and records the change under `0.4` in `changes.txt`
   referencing your `ba7132b7e`.

## Verification

Ran locally on Linux:

```
$ (cd tests/s/mini && mk hello_macos_amd64.exe hello_macos_libc_amd64.exe hello_linux_amd64.exe)
$ file hello_macos_{amd64,libc_amd64}.exe
hello_macos_amd64.exe:      Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
hello_macos_libc_amd64.exe: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
$ darling shell ./hello_macos_libc_amd64.exe
Hello, world
$ ./hello_linux_amd64.exe                    # ELF, byte-identical to master
Hello, world
```

`(cd tests/s/mini && mk clean && mk all)` builds every existing target.
The full 7l/arm64 side (\`hello_macos_arm64.exe\`, ad-hoc code
signature, ADRP/ADD, `linkers/lk/macho.c`) comes from your master
untouched.

## What's *not* here (versus #5)

Dropped:
- 7l `LC_MAIN` / ad-hoc `LC_CODE_SIGNATURE` / `sha256.c` -- your
  `ba7132b7e` does the equivalent via `linkers/lk/macho.c`.
- 7l `-I` dynimports and \`hello_macos_libc_arm64.s\` -- would land as
  a follow-up on your arm64 path.
- 7l PIE via `ADR` -- your `ba7132b7e` uses ADRP/ADD, which is the
  right shape.
- Debian packaging -- unrelated, will land separately if useful.
- `README.md` prose changes -- your \`57968451b\` already covers this.

Known limitations still noted in the notes file:
- `__PAGEZERO` is 1 MB, not Apple's 4 GB, because 6l's text layout uses
  int32 offsets.  `MH_PIE` lets dyld slide the image regardless, so
  this is cosmetic.
- No amd64 ad-hoc code signature.  XNU still accepts unsigned amd64
  binaries; the LINKEDIT slack for `codesign(1)` is intentionally left
  reachable.

Original PR: #5.