### PR TITLE
8l: Windows 386 PE that prints via kernel32 (-H 10)

### DIFF
--- a/src/cmd/8l/obj.c
+++ b/src/cmd/8l/obj.c
@@ -246,6 +246,11 @@ main(int argc, char *argv[])
 		break;
 	case 10: /* PE executable */
 		peinit();
+		// asmbpe() would emit a .symdat section after .idata when not
+		// stripped, which perturbs the section layout the import table
+		// relies on; force -s (the .exe runs fine without symbols, and
+		// this matches 6l -H 10).
+		debug['s'] = 1;
 		HEADR = PERESERVE;
 		if(INITTEXT == -1)
 			INITTEXT = PEBASE+0x1000;
@@ -313,9 +318,12 @@ main(int argc, char *argv[])
 		else
 			doprof2();
 	span();
-	reloc();
+	// PE: lay out sections and define the __imp_* import symbols before
+	// reloc() so that references to them (MOVL __imp_WriteFile(SB), AX; ...)
+	// resolve to the right IAT slot addresses.
 	if(HEADTYPE == 10)
 		dope();
+	reloc();
 	asmb();
 	undef();
 	if(debug['v']) {

--- a/tests/s/mini/hello_windows_386.s
+++ b/tests/s/mini/hello_windows_386.s
@@ -1,0 +1,45 @@
+// "Hello, World!" for 8l_ -H 10 (PE32 for Windows x86).
+//
+// 8l emits a kernel32.dll import table and exposes each thunk as an
+// __imp_<name> symbol pointing at its IAT slot (see src/cmd/ld/pe.c). The
+// slot holds the resolved function pointer once the loader binds it, so we
+// load it and call indirectly (MOVL __imp_<name>(SB), AX; CALL AX). A
+// direct "CALL __imp_<name>(SB)" would be rejected by the linker's patch()
+// pass, which expects direct call targets to be text symbols.
+//
+// Win32 __stdcall: arguments go on the stack right-to-left and the callee
+// pops them (RET n), so ESP is back where it started after each call. We
+// reserve the argument area with SUBL and fill it with MOVL rather than
+// PUSHL: 8l statically balances PUSH/POP within a function and can't see
+// that the callee does the popping, so PUSHL would trip "unbalanced
+// PUSH/POP". Results come back in AX.
+
+TEXT	_start(SB), $0
+	// h = GetStdHandle(STD_OUTPUT_HANDLE = -11)
+	SUBL	$4, SP
+	MOVL	$-11, 0(SP)
+	MOVL	__imp_GetStdHandle(SB), AX
+	CALL	AX			// stdcall pops its arg; SP restored
+	MOVL	AX, BX			// save handle (EBX is nonvolatile)
+
+	// WriteFile(h, msg, 14, &written, NULL)
+	SUBL	$20, SP
+	MOVL	BX, 0(SP)		// hFile
+	MOVL	$msg(SB), 4(SP)		// lpBuffer
+	MOVL	$14, 8(SP)		// nNumberOfBytesToWrite
+	MOVL	$written(SB), 12(SP)	// lpNumberOfBytesWritten
+	MOVL	$0, 16(SP)		// lpOverlapped = NULL
+	MOVL	__imp_WriteFile(SB), AX
+	CALL	AX
+
+	// ExitProcess(0)
+	SUBL	$4, SP
+	MOVL	$0, 0(SP)
+	MOVL	__imp_ExitProcess(SB), AX
+	CALL	AX
+	RET
+
+DATA	msg+0(SB)/8, $"Hello, W"
+DATA	msg+8(SB)/6, $"orld!\n"
+GLOBL	msg(SB), $14
+GLOBL	written(SB), $4

--- a/tests/s/mini/mkfile
+++ b/tests/s/mini/mkfile
@@ -13,8 +13,7 @@ PLAN9BINS=hello_plan9_386.exe hello_plan9_arm.exe hello_plan9_mips.exe
 XV6BINS=
 
 MACOSBINS=hello_macos_amd64.exe hello_macos_arm64.exe hello_macos_libc_amd64.exe
-#TODO: hello_windows_386.exe
-WINDOWSBINS=hello_windows_amd64.exe
+WINDOWSBINS=hello_windows_386.exe hello_windows_amd64.exe
 
 all:V: $LINUXBINS $EXITLINUXBINS $MACOSBINS $WINDOWSBINS $PLAN9BINS $XV6BINS
 
@@ -112,11 +111,17 @@ hello_plan9_mips.exe: hello_plan9_mips.s
    va -c $prereq
    vl -o $target -H 2 -E _main hello_plan9_mips.v
 
-# Windows (PE). amd64 uses 6l -H 10, which emits a PE32+ (64-bit)
-# optional header; -s because 6l has no PE symbol table path yet. It
-# links a kernel32.dll .idata (GetStdHandle, WriteFile, ExitProcess)
-# and exposes the thunks as __imp_* symbols so the program can print.
-# See src/cmd/ld/pe.c. Test under wine on Linux hosts.
+# Windows (PE). Both link a kernel32.dll .idata (GetStdHandle, WriteFile,
+# ExitProcess) and expose the thunks as __imp_* symbols so the program can
+# print. See src/cmd/ld/pe.c. -s because there is no PE symbol table path
+# yet. Test under wine on Linux hosts.
+#
+# 386 uses 8l_ (kencc lineage): the principia 8l in linkers/8l/ does not
+# have -H 10 wired. amd64 uses 6l -H 10, which emits a PE32+ (64-bit)
+# optional header.
+hello_windows_386.exe: hello_windows_386.s
+   8a_ $prereq
+   8l_ -s -H 10 -o $target -E _start hello_windows_386.8
 hello_windows_amd64.exe: hello_windows_amd64.s
    6a -c $prereq
    6l -s -H 10 -o $target -E _start hello_windows_amd64.6


### PR DESCRIPTION
## Summary
- 386 PE (`8l_ -H 10`) now prints to the console instead of just returning.
- Wires `8l`'s pass order and makes `hello_windows_386.s` call `GetStdHandle` + `WriteFile` + `ExitProcess` using the shared PE import machinery.

## Details
- `src/cmd/8l/obj.c`: call `dope()` before `reloc()` so the `__imp_*` import symbols resolve; force `-s` for `-H 10` (avoids a `.symdat` section that would perturb the import layout; matches `6l`).
- `hello_windows_386.s`: prints via the Win32 `__stdcall` convention. The arg area is reserved with `SUBL`/`MOVL` rather than `PUSHL` because `8l` statically balances PUSH/POP and can't see the callee pop. Thunks are called indirectly (`MOVL __imp_WriteFile(SB), AX; CALL AX`).
- `mkfile`: build with `8l_ -s -H 10`, enabled in `WINDOWSBINS` alongside amd64.

## Stacking (please read)
This PR is **stacked on top of #8** and, because GitHub cross-fork PRs can't use a fork branch as base, its diff **also contains #8's commit** (`6l: PE32+ output for Windows amd64`). The 386 printing reuses the shared kernel32 import machinery that #8 introduces in `src/cmd/ld/pe.c`. Please review/merge #8 first; then this PR reduces to just the `8l` commit. (Happy to squash both into one PR if you prefer.)

## Test plan
- [x] `8l_ -s -H 10` builds a `PE32 executable (console) Intel 80386`.
- [x] Runs under `wine`: prints `Hello, World!`, exits 0.
- [x] `mk all` in `tests/s/mini` passes; plan9 386 (`-H 2`) path unaffected.
