### PR TITLE
6l: link pe.o in the Makefile (fix Docker/make.bash build regression)

### DIFF
--- a/src/cmd/6l/Makefile
+++ b/src/cmd/6l/Makefile
@@ -21,6 +21,7 @@ OFILES=\
 	obj.$O\
 	optab.$O\
 	pass.$O\
+	pe.$O\
 	prof.$O\
 	span.$O\
 	symtab.$O\
@@ -31,6 +32,7 @@ HFILES=\
 	../ld/lib.h\
 	../ld/elf.h\
 	../ld/macho.h\
+	../ld/pe.h\
 	../ld/dwarf.h\
 
 include ../../Make.ccmd


### PR DESCRIPTION
The `docker` workflow's `build-alpine` and `build-golang` jobs regressed on master (e.g. run 29743655231): `GO/make.bash` links `6l` without `pe.o`, so the PE functions added by the amd64 Windows work (#8) are undefined:

```
src/cmd/6l/asm.c:763: undefined reference to `asmbpe'
src/cmd/6l/obj.c:223: undefined reference to `peinit'
src/cmd/6l/obj.c:290: undefined reference to `dope'
collect2: error: ld returned 1 exit status
make: *** [../../Make.ccmd:13: 6l] Error 1
```

## Cause
#8 added the `asmbpe`/`peinit`/`dope` calls in `src/cmd/6l/{asm,obj}.c` and wired `pe.$O` into `src/cmd/6l/mkfile` (the `mk` build — which is why `build-via-mkrc` stays green), but not into `src/cmd/6l/Makefile` (the `make.bash`/`Make.ccmd` build used by `Dockerfile.alpine` and `Dockerfile.golang`). So that build links `6l` without `pe.o`. `src/cmd/8l/Makefile` already lists `pe.$O`, so only 6l was affected.

## Fix
Add `pe.$O` to `OFILES` and `../ld/pe.h` to `HFILES` in `src/cmd/6l/Makefile`, matching the working `mkfile`.

## Test plan
- [x] `cd GO && ./make.bash` now builds `6l` cleanly (no undefined references).
- [x] `mk` build (`build-via-mkrc`) already green and unaffected.

See discussion in #8.